### PR TITLE
회원가입/로그인수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>

--- a/src/main/java/com/team/infra_team2/user/exception/CustomException.java
+++ b/src/main/java/com/team/infra_team2/user/exception/CustomException.java
@@ -1,0 +1,21 @@
+package com.team.infra_team2.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+	private final HttpStatus status;
+
+	public CustomException(String message) {
+		super(message);
+		this.status = HttpStatus.BAD_REQUEST;
+	}
+
+	public CustomException(String message, HttpStatus status) {
+		super(message);
+		this.status = status;
+	}
+
+	public HttpStatus getStatus() {
+		return status;
+	}
+}

--- a/src/main/java/com/team/infra_team2/user/request/UserSignupRequestDTO.java
+++ b/src/main/java/com/team/infra_team2/user/request/UserSignupRequestDTO.java
@@ -3,6 +3,9 @@ package com.team.infra_team2.user.request;
 import com.team.infra_team2.user.constant.UserRoleType;
 import com.team.infra_team2.user.entity.User;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -11,7 +14,13 @@ import lombok.ToString;
 @Setter
 public class UserSignupRequestDTO {
 
+
+	@NotBlank(message = "아이디는 필수 입력값입니다.")
+	@Pattern(regexp = "^[a-zA-Z0-9]{6,12}$", message = "아이디는 영문과 숫자 조합 6~12자여야 합니다.")
 	private String username;
+	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
+	@Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+	@Pattern(regexp = ".*[!@#$%^&*()_+=\\-\\[\\]{};':\"\\\\|,.<>/?].*", message = "비밀번호는 특수문자를 최소 1개 포함해야 합니다.")
 	private String password;
 
 	public User toEntity() {

--- a/src/main/java/com/team/infra_team2/user/service/SecurityService.java
+++ b/src/main/java/com/team/infra_team2/user/service/SecurityService.java
@@ -1,0 +1,69 @@
+package com.team.infra_team2.user.service;
+
+import javax.naming.AuthenticationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import com.team.infra_team2.user.entity.User;
+import com.team.infra_team2.user.exception.CustomException;
+import com.team.infra_team2.user.repository.UserRepository;
+import com.team.infra_team2.user.request.UserLoginRequestDTO;
+import com.team.infra_team2.user.request.UserSignupRequestDTO;
+import com.team.infra_team2.user.security.config.auth.PrincipalDetails;
+
+@Service
+public class SecurityService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final AuthenticationManager authenticationManager;
+
+	public SecurityService(UserRepository userRepository, PasswordEncoder passwordEncoder,
+			AuthenticationManager authenticationManager) {
+		this.userRepository = userRepository;
+		this.passwordEncoder = passwordEncoder;
+		this.authenticationManager = authenticationManager;
+	}
+
+	public boolean login(UserLoginRequestDTO dto) throws AuthenticationException {
+		try {
+			Authentication authentication = authenticationManager
+					.authenticate(new UsernamePasswordAuthenticationToken(dto.getUsername(), dto.getPassword()));
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			return true;
+		} catch (UsernameNotFoundException e) {
+			throw new CustomException("존재하지 않는 아이디입니다.", HttpStatus.NOT_FOUND);
+		} catch (BadCredentialsException e) {
+			throw new CustomException("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED);
+		}
+	}
+
+	public User signup(UserSignupRequestDTO requestDTO) {
+		// 유저 중복 체크
+		if (userRepository.findByUsername(requestDTO.getUsername()) != null) {
+			throw new CustomException("이미 존재하는 아이디입니다.");
+		}
+
+		String rawPassword = requestDTO.getPassword();
+		String encryptedPassword = passwordEncoder.encode(rawPassword);
+
+		User user = requestDTO.toEntity();
+		user.setPassword(passwordEncoder.encode(requestDTO.getPassword()));
+		return userRepository.save(user);
+	}
+
+	public String getCurrentUsername() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth != null && auth.getPrincipal() instanceof PrincipalDetails principal) {
+			return principal.getUsername();
+		}
+		return null;
+	}
+
+}

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -12,6 +12,13 @@
 
 	<div class="container mt-5">
 		<h2>로그인</h2>
+		<!-- 에러 메시지 표시 영역 -->
+		<div th:if="${validationErrors}" class="alert alert-danger">
+			<ul>
+				<li th:each="err : ${validationErrors}" th:text="${err}"></li>
+			</ul>
+		</div>
+
 		<form th:action="@{/api/auth/login}" method="post">
 			<div class="mb-3">
 				<label for="username" class="form-label">아이디</label>
@@ -25,6 +32,7 @@
 			<a th:href="@{/api/auth/signup}" class="btn btn-link">회원가입</a>
 		</form>
 	</div>
+	<div th:if="${error}" class="alert alert-danger mt-3" th:text="${error}"></div>
 </body>
 
 </html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -12,14 +12,18 @@
     <!-- POST 요청을 /api/auth/signup 으로 보냄 -->
     <!-- th:object는 컨트롤러에서 전달한 DTO 객체 -->
     <form th:action="@{/api/auth/signup}" th:object="${userSignupRequestDTO}" method="post">
-        <div class="mb-3">
-            <label for="username" class="form-label">아이디</label>
-            <input type="text" th:field="*{username}" class="form-control" id="username" required>
-        </div>
-        <div class="mb-3">
-            <label for="password" class="form-label">비밀번호</label>
-            <input type="password" th:field="*{password}" class="form-control" id="password" required>
-        </div>
+			<div class="mb-3">
+			    <label for="username" class="form-label">아이디</label>
+			    <input type="text" th:field="*{username}" class="form-control" id="username" required>
+			    <div th:if="${#fields.hasErrors('username')}" class="text-danger" th:errors="*{username}"></div>
+			</div>
+			
+			<!-- 비밀번호 입력 -->
+			<div class="mb-3">
+			    <label for="password" class="form-label">비밀번호</label>
+			    <input type="password" th:field="*{password}" class="form-control" id="password" required>
+			    <div th:if="${#fields.hasErrors('password')}" class="text-danger" th:errors="*{password}"></div>
+			</div>
         <button type="submit" class="btn btn-primary">회원가입</button>
     </form>
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- refactor/login-new-branch

### 🔑 주요 변경사항

- controller 기존에 로직 구현 -> 서비스로 이동시킴
- 같은 이름 회원가입 방지 처리 
- 회원가입 벨리데이션 적용 (아이디 및 비번) ->피그마에 작성한 내역과 맞춤


### 🏞 스크린샷

![중복체크 화면](https://github.com/user-attachments/assets/f425fda4-0bb7-416e-af65-dd42d785367f)

검증방법1:  기존에 생성한 아이디로 회원가입 시도

검증방법2:  
사용자 ID (영문/숫자, 6~12자)
비밀번호 (8자 이상, 특수문자 포함 가능)
이외의 값으로 회원가입 시도.

검증방법3: 가입때 사용한 로그인과 비번을 다르게 입력


### 관련 이슈
-브랜치 꼬임으로 인해 -> 기본 로그인 기능 체크가 필요함 (로컬에선 체크 다른팀원 크로스체크 필요함)
